### PR TITLE
Fix MediaFlowInStateChange crash: Lock mutex around calls to sigc++

### DIFF
--- a/src/server/implementation/objects/ZBarFilterImpl.cpp
+++ b/src/server/implementation/objects/ZBarFilterImpl.cpp
@@ -115,6 +115,8 @@ ZBarFilterImpl::barcodeDetected (guint64 ts, std::string &type,
 
     try {
       CodeFound event (shared_from_this(), CodeFound::getName(), type, symbol);
+
+      std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
       signalCodeFound (event);
     } catch (std::bad_weak_ptr &e) {
     }

--- a/src/server/implementation/objects/ZBarFilterImpl.cpp
+++ b/src/server/implementation/objects/ZBarFilterImpl.cpp
@@ -116,8 +116,7 @@ ZBarFilterImpl::barcodeDetected (guint64 ts, std::string &type,
     try {
       CodeFound event (shared_from_this(), CodeFound::getName(), type, symbol);
 
-      std::unique_lock<std::recursive_mutex> sigcLock (sigcMutex);
-      signalCodeFound (event);
+      sigcSignalEmit(signalCodeFound, event);
     } catch (std::bad_weak_ptr &e) {
     }
   }


### PR DESCRIPTION
libsigc++ signal/slot mechanism is *not thread-safe*. All signal emitters must coordinate with a mutex, or else multiple threads might try to emit at the same time, breaking the library.

Repos:
* Kurento/kms-core#19
* Kurento/kms-elements#19
* Kurento/kms-filters#4